### PR TITLE
[Feat] 클러스터링 추가

### DIFF
--- a/app/api/cluster/route.ts
+++ b/app/api/cluster/route.ts
@@ -1,0 +1,63 @@
+import { handleErrorResponse } from 'app/api/_utils/errorHandler';
+import { cookies } from 'next/headers';
+import { NextResponse } from 'next/server';
+import { createClient } from 'utils/supabase/server';
+
+export async function GET(request: Request) {
+  const cookieStore = cookies();
+  const supabase = createClient(cookieStore);
+  const url = new URL(request.url);
+  const categoriesStr = url.searchParams.get('category');
+  const categories = categoriesStr ? categoriesStr.split(',') : [];
+  const latitude = url.searchParams.get('latitude');
+  const longitude = url.searchParams.get('longitude');
+  const latitudeDelta = url.searchParams.get('latitudeDelta');
+  const longitudeDelta = url.searchParams.get('longitudeDelta');
+
+  const northEastBoundary = {
+    latitude: Number(latitude) + Number(latitudeDelta),
+    longitude: Number(longitude) + Number(longitudeDelta),
+  };
+
+  const southWestBoundary = {
+    latitude: Number(latitude) - Number(latitudeDelta),
+    longitude: Number(longitude) - Number(longitudeDelta),
+  };
+
+  const isLatitudeWithinBounds = ({ x_code }: { x_code: number }) => {
+    return (
+      x_code > southWestBoundary.latitude && x_code < northEastBoundary.latitude
+    );
+  };
+
+  const isLongitudeWithinBounds = ({ y_code }: { y_code: number }) => {
+    return (
+      y_code > southWestBoundary.longitude &&
+      y_code < northEastBoundary.longitude
+    );
+  };
+
+  try {
+    const { data, error } = await supabase
+      .from('traffic_hub')
+      .select('*')
+      .or(categories.map((category) => `source.eq.${category}`).join(','));
+
+    if (error) {
+      throw new Error(error.message);
+    }
+
+    const foundMarker = data.filter(
+      (marker) =>
+        isLatitudeWithinBounds({ x_code: marker.x_code }) &&
+        isLongitudeWithinBounds({ y_code: marker.y_code }),
+    );
+
+    return new NextResponse(JSON.stringify(foundMarker), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (error) {
+    return handleErrorResponse(error);
+  }
+}

--- a/app/api/clusters/route.ts
+++ b/app/api/clusters/route.ts
@@ -64,7 +64,7 @@ export async function GET(request: Request) {
       distanceFunction: squaredEuclidean,
     };
 
-    const k = 10;
+    const k = 20; // cluster 개수
     const points = foundMarker.map((marker) => [marker.x_code, marker.y_code]);
     const result = kmeans(points, k, defaultOptions);
 

--- a/app/api/traffic/route.ts
+++ b/app/api/traffic/route.ts
@@ -47,8 +47,6 @@ export async function GET(request: Request) {
       throw new Error(error.message);
     }
 
-    console.log('data', data.length);
-
     const foundMarker = data.filter(
       (marker) =>
         isLatitudeWithinBounds({ x_code: marker.x_code }) &&

--- a/app/globals.css
+++ b/app/globals.css
@@ -142,3 +142,16 @@
   position: relative;
   display: inline-block;
 }
+
+/* Marker cluster animation */
+@keyframes fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+.animate-fade-in {
+  animation: fade-in 0.5s ease-out;
+}

--- a/components/map/cluster.tsx
+++ b/components/map/cluster.tsx
@@ -13,9 +13,10 @@ const ClusterMarker: React.FC<ClusterMarkerProps> = ({ cluster }) => {
   if (!mapStore) return;
   const googleMap = mapStore.getState();
   const { id, latitude, longitude, count } = cluster;
-  const container = document.createElement('div');
 
   useEffect(() => {
+    const container = document.createElement('div');
+
     const markerInstance = new google.maps.marker.AdvancedMarkerElement({
       position: {
         lat: latitude,
@@ -32,12 +33,7 @@ const ClusterMarker: React.FC<ClusterMarkerProps> = ({ cluster }) => {
       </div>,
     );
 
-    const infoWindow = new google.maps.InfoWindow({
-      content: container,
-    });
-
     markerInstance.addListener('click', () => {
-      infoWindow.open(googleMap, markerInstance);
       googleMap.panTo({ lat: latitude, lng: longitude });
 
       const currentZoomLevel = googleMap.getZoom();

--- a/components/map/cluster.tsx
+++ b/components/map/cluster.tsx
@@ -14,44 +14,43 @@ const ClusterMarker = ({ traffic }: any) => {
   if (!mapStore) return;
   const googleMap = mapStore.getState();
   const { id, latitude, longitude, count } = traffic;
+  const container = document.createElement('div');
 
   useEffect(() => {
-    const position = new google.maps.LatLng(latitude, longitude);
-    const marker = new google.maps.Marker({
-      position,
+    const markerInstance = new google.maps.marker.AdvancedMarkerElement({
+      position: {
+        lat: latitude,
+        lng: longitude,
+      },
       map: googleMap,
       title: `Cluster ${id}`,
+      content: container,
     });
 
-    const container = document.createElement('div');
-
-    console.log('counte', count);
-
     createRoot(container).render(
-      <div className="size-full bg-red-500">{count}</div>,
+      <div className="animate-fade-in flex size-16 items-center justify-center rounded-full border border-blue-600 bg-blue-200 p-4 text-lg font-bold">
+        <span>{count}</span>
+      </div>,
     );
 
     const infoWindow = new google.maps.InfoWindow({
       content: container,
     });
 
-    marker.addListener('click', () => {
-      infoWindow.open(googleMap, marker);
-      googleMap.panTo(position);
+    markerInstance.addListener('click', () => {
+      infoWindow.open(googleMap, markerInstance);
+      googleMap.panTo({ lat: latitude, lng: longitude });
 
-      // 현재 줌 레벨을 가져오고, -1하여 새로운 줌 레벨로 설정
       const currentZoomLevel = googleMap.getZoom();
-      if (currentZoomLevel !== null && currentZoomLevel > 0) {
-        googleMap.setZoom(currentZoomLevel + 1);
-      }
+      currentZoomLevel && googleMap.setZoom(currentZoomLevel + 1);
     });
 
     return () => {
-      marker.setMap(null);
+      markerInstance.map = null;
     };
-  }, [id, count, latitude, longitude, googleMap]);
+  }, []);
 
-  return null;
+  return <></>;
 };
 
 export default ClusterMarker;

--- a/components/map/cluster.tsx
+++ b/components/map/cluster.tsx
@@ -2,18 +2,17 @@ import { useEffect } from 'react';
 import { createRoot } from 'react-dom/client';
 import { getGoogleMapStore } from 'store/googleMapStore';
 
+import { type Cluster } from './marker-container';
+
 type ClusterMarkerProps = {
-  id: number;
-  latitude: number;
-  longitude: number;
-  count: number;
+  cluster: Cluster;
 };
 
-const ClusterMarker = ({ traffic }: any) => {
+const ClusterMarker: React.FC<ClusterMarkerProps> = ({ cluster }) => {
   const mapStore = getGoogleMapStore?.();
   if (!mapStore) return;
   const googleMap = mapStore.getState();
-  const { id, latitude, longitude, count } = traffic;
+  const { id, latitude, longitude, count } = cluster;
   const container = document.createElement('div');
 
   useEffect(() => {

--- a/components/map/cluster.tsx
+++ b/components/map/cluster.tsx
@@ -1,0 +1,57 @@
+import { useEffect } from 'react';
+import { createRoot } from 'react-dom/client';
+import { getGoogleMapStore } from 'store/googleMapStore';
+
+type ClusterMarkerProps = {
+  id: number;
+  latitude: number;
+  longitude: number;
+  count: number;
+};
+
+const ClusterMarker = ({ traffic }: any) => {
+  const mapStore = getGoogleMapStore?.();
+  if (!mapStore) return;
+  const googleMap = mapStore.getState();
+  const { id, latitude, longitude, count } = traffic;
+
+  useEffect(() => {
+    const position = new google.maps.LatLng(latitude, longitude);
+    const marker = new google.maps.Marker({
+      position,
+      map: googleMap,
+      title: `Cluster ${id}`,
+    });
+
+    const container = document.createElement('div');
+
+    console.log('counte', count);
+
+    createRoot(container).render(
+      <div className="size-full bg-red-500">{count}</div>,
+    );
+
+    const infoWindow = new google.maps.InfoWindow({
+      content: container,
+    });
+
+    marker.addListener('click', () => {
+      infoWindow.open(googleMap, marker);
+      googleMap.panTo(position);
+
+      // 현재 줌 레벨을 가져오고, -1하여 새로운 줌 레벨로 설정
+      const currentZoomLevel = googleMap.getZoom();
+      if (currentZoomLevel !== null && currentZoomLevel > 0) {
+        googleMap.setZoom(currentZoomLevel + 1);
+      }
+    });
+
+    return () => {
+      marker.setMap(null);
+    };
+  }, [id, count, latitude, longitude, googleMap]);
+
+  return null;
+};
+
+export default ClusterMarker;

--- a/components/map/map-container.tsx
+++ b/components/map/map-container.tsx
@@ -2,29 +2,16 @@
 
 import { Status, Wrapper } from '@googlemaps/react-wrapper';
 import { LoadingSpinner } from 'components/common/loading-spinner';
-import { LegendCheckboxManager } from 'components/legend/checkbox-manager';
-import { MarkerContainer } from 'components/map/marker-container';
-import { useCategoryFilter } from 'hooks/useCategoryFilter';
-import { GoogleMap } from 'lib/google-map';
+import { TrafficHubMap } from 'components/map/traffic-hub';
 
 const render = (status: Status) => {
-  const { handleCategoryChange, selectedCategory } = useCategoryFilter();
-
   switch (status) {
     case Status.LOADING:
       return <LoadingSpinner />;
     case Status.FAILURE:
       return <>에러 발생</>;
     case Status.SUCCESS:
-      return (
-        <LegendCheckboxManager
-          selectedCategory={selectedCategory}
-          handleCategoryChange={handleCategoryChange}
-        >
-          <GoogleMap />
-          <MarkerContainer selectedCategory={selectedCategory} />
-        </LegendCheckboxManager>
-      );
+      return <TrafficHubMap />;
   }
 };
 

--- a/components/map/marker-container.tsx
+++ b/components/map/marker-container.tsx
@@ -9,6 +9,10 @@ const TrafficMapMarker = dynamic(() => import('@/components/map/marker'), {
   ssr: false,
 });
 
+const ClusterMapMarker = dynamic(() => import('@/components/map/cluster'), {
+  ssr: false,
+});
+
 type MarkerContainerProps = {
   selectedCategory: Set<string>;
 };
@@ -18,7 +22,6 @@ export const MarkerContainer: React.FC<MarkerContainerProps> = ({
 }) => {
   const mapStore = getGoogleMapStore?.();
   if (!mapStore) return;
-
   const googleMaps = useExternalValue(mapStore);
   const [currentZoomLevel, setCurrentZoomLevel] = useState(
     googleMaps?.getZoom(),
@@ -44,7 +47,13 @@ export const MarkerContainer: React.FC<MarkerContainerProps> = ({
   });
 
   if (currentZoomLevel && currentZoomLevel <= 13) {
-    return null;
+    return (
+      <>
+        {traffic.data?.map((traffic: TrafficHub) => {
+          return <ClusterMapMarker key={traffic.id} traffic={traffic} />;
+        })}
+      </>
+    );
   }
 
   if (traffic.data === undefined) {

--- a/components/map/marker-container.tsx
+++ b/components/map/marker-container.tsx
@@ -17,6 +17,13 @@ type MarkerContainerProps = {
   selectedCategory: Set<string>;
 };
 
+export type Cluster = {
+  id: number;
+  latitude: number;
+  longitude: number;
+  count: number;
+};
+
 export const MarkerContainer: React.FC<MarkerContainerProps> = ({
   selectedCategory,
 }) => {
@@ -47,13 +54,9 @@ export const MarkerContainer: React.FC<MarkerContainerProps> = ({
   });
 
   if (currentZoomLevel && currentZoomLevel <= 13) {
-    return (
-      <>
-        {traffic.data?.map((traffic: TrafficHub) => {
-          return <ClusterMapMarker key={traffic.id} traffic={traffic} />;
-        })}
-      </>
-    );
+    return traffic.data?.map((cluster: Cluster) => (
+      <ClusterMapMarker key={cluster.id} cluster={cluster} />
+    ));
   }
 
   if (traffic.data === undefined) {

--- a/components/map/marker-container.tsx
+++ b/components/map/marker-container.tsx
@@ -1,6 +1,9 @@
 import { type TrafficHub } from 'app/page';
+import { useExternalValue } from 'external-state';
 import { useTrafficGetQuery } from 'hooks/useTrafficGetQuery';
 import dynamic from 'next/dynamic';
+import { useEffect, useState } from 'react';
+import { getGoogleMapStore } from 'store/googleMapStore';
 
 const TrafficMapMarker = dynamic(() => import('@/components/map/marker'), {
   ssr: false,
@@ -13,7 +16,36 @@ type MarkerContainerProps = {
 export const MarkerContainer: React.FC<MarkerContainerProps> = ({
   selectedCategory,
 }) => {
-  const { traffic } = useTrafficGetQuery({ categoryFilter: selectedCategory });
+  const mapStore = getGoogleMapStore?.();
+  if (!mapStore) return;
+
+  const googleMaps = useExternalValue(mapStore);
+  const [currentZoomLevel, setCurrentZoomLevel] = useState(
+    googleMaps?.getZoom(),
+  );
+
+  useEffect(() => {
+    if (!googleMaps) return;
+
+    const onZoomChanged = () => {
+      setCurrentZoomLevel(googleMaps.getZoom());
+    };
+
+    const listener = googleMaps.addListener('zoom_changed', onZoomChanged);
+
+    return () => {
+      google.maps.event.removeListener(listener);
+    };
+  }, [googleMaps]);
+
+  const { traffic } = useTrafficGetQuery({
+    categoryFilter: selectedCategory,
+    currentZoomLevel,
+  });
+
+  if (currentZoomLevel && currentZoomLevel <= 13) {
+    return null;
+  }
 
   if (traffic.data === undefined) {
     return null;

--- a/components/map/marker.tsx
+++ b/components/map/marker.tsx
@@ -27,7 +27,7 @@ const TrafficMapMarker = ({ traffic }: TrafficMapMarkerProps) => {
     const trafficVolume = traffic?.[aadtKey];
     const marker = getMarkerImage(source, roadType);
     const container = document.createElement('div');
-    container.className = 'marker-container';
+    container.className = 'marker-container animate-fade-in';
 
     const markerInstance = new google.maps.marker.AdvancedMarkerElement({
       position: { lat: latitude, lng: longitude },

--- a/components/map/traffic-hub.tsx
+++ b/components/map/traffic-hub.tsx
@@ -1,0 +1,18 @@
+import { LegendCheckboxManager } from 'components/legend/checkbox-manager';
+import { MarkerContainer } from 'components/map/marker-container';
+import { useCategoryFilter } from 'hooks/useCategoryFilter';
+import { GoogleMap } from 'lib/google-map';
+
+export const TrafficHubMap = () => {
+  const { handleCategoryChange, selectedCategory } = useCategoryFilter();
+
+  return (
+    <LegendCheckboxManager
+      selectedCategory={selectedCategory}
+      handleCategoryChange={handleCategoryChange}
+    >
+      <GoogleMap />
+      <MarkerContainer selectedCategory={selectedCategory} />
+    </LegendCheckboxManager>
+  );
+};

--- a/constant/location.ts
+++ b/constant/location.ts
@@ -38,4 +38,6 @@ export const REGION: Region[] = [
 ];
 
 export const INITIAL_ZOOM_LEVEL = 12;
+export const MIN_ZOOM_LEVEL = 7;
+export const MAX_ZOOM_LEVEL = 20;
 export const SHOW_MARKER_ZOOM_LEVEL = 7;

--- a/hooks/useTrafficGetQuery.ts
+++ b/hooks/useTrafficGetQuery.ts
@@ -1,8 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
+import { trafficManagerKeys } from 'lib/query/queryFactory';
 import { getGoogleMapStore } from 'store/googleMapStore';
 import { getDisplayPosition } from 'utils/getDisplayPosition';
-
-import { trafficManagerKeys } from '@/lib/query/queryFactory';
 
 const fetchTraffic = async ({ categoryFilter }: UseTrafficGetQueryType) => {
   const mapStore = getGoogleMapStore?.();
@@ -44,7 +43,6 @@ export const useTrafficGetQuery = ({
       Array.from(categoryFilter || []).join(','),
     ],
     queryFn: () => fetchTraffic({ categoryFilter }),
-    refetchOnWindowFocus: false,
   });
 
   return {

--- a/hooks/useTrafficGetQuery.ts
+++ b/hooks/useTrafficGetQuery.ts
@@ -3,6 +3,34 @@ import { trafficManagerKeys } from 'lib/query/queryFactory';
 import { getGoogleMapStore } from 'store/googleMapStore';
 import { getDisplayPosition } from 'utils/getDisplayPosition';
 
+const fetchCluster = async ({ categoryFilter }: UseTrafficGetQueryType) => {
+  const mapStore = getGoogleMapStore?.();
+  if (!mapStore) return;
+
+  const { latitudeDelta, longitudeDelta, longitude, latitude } =
+    getDisplayPosition(mapStore.getState());
+
+  const url = new URL(
+    `${process.env.NEXT_PUBLIC_API_URL}/api/traffic/clusters`,
+  );
+  url.searchParams.append('latitude', latitude.toString());
+  url.searchParams.append('longitude', longitude.toString());
+  url.searchParams.append('latitudeDelta', latitudeDelta.toString());
+  url.searchParams.append('longitudeDelta', longitudeDelta.toString());
+  url.searchParams.append(
+    'category',
+    Array.from(categoryFilter || []).join(','),
+  );
+
+  const res = await fetch(url);
+
+  if (!res.ok) {
+    throw new Error('마커를 불러오는데 실패했어요..!');
+  }
+
+  return await res.json();
+};
+
 const fetchTraffic = async ({ categoryFilter }: UseTrafficGetQueryType) => {
   const mapStore = getGoogleMapStore?.();
   if (!mapStore) return;
@@ -31,18 +59,25 @@ const fetchTraffic = async ({ categoryFilter }: UseTrafficGetQueryType) => {
 
 type UseTrafficGetQueryType = {
   categoryFilter?: Set<string>;
+  currentZoomLevel?: number;
 };
 
 export const useTrafficGetQuery = ({
   categoryFilter,
+  currentZoomLevel,
 }: UseTrafficGetQueryType) => {
+  const queryFunction =
+    currentZoomLevel && currentZoomLevel >= 13 ? fetchTraffic : fetchCluster;
+
   const traffic = useQuery({
     queryKey: [
       ...trafficManagerKeys.traffic,
       'category',
       Array.from(categoryFilter || []).join(','),
+      'zoomLevel',
+      currentZoomLevel,
     ],
-    queryFn: () => fetchTraffic({ categoryFilter }),
+    queryFn: () => queryFunction({ categoryFilter }),
   });
 
   return {

--- a/hooks/useTrafficGetQuery.ts
+++ b/hooks/useTrafficGetQuery.ts
@@ -10,9 +10,7 @@ const fetchCluster = async ({ categoryFilter }: UseTrafficGetQueryType) => {
   const { latitudeDelta, longitudeDelta, longitude, latitude } =
     getDisplayPosition(mapStore.getState());
 
-  const url = new URL(
-    `${process.env.NEXT_PUBLIC_API_URL}/api/traffic/clusters`,
-  );
+  const url = new URL(`${process.env.NEXT_PUBLIC_API_URL}/api/clusters`);
   url.searchParams.append('latitude', latitude.toString());
   url.searchParams.append('longitude', longitude.toString());
   url.searchParams.append('latitudeDelta', latitudeDelta.toString());

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "external-state": "^0.1.22",
         "geist": "^1.0.0",
         "lucide-react": "^0.307.0",
+        "ml-kmeans": "^6.0.0",
         "next": "latest",
         "open-color": "^1.9.1",
         "postcss": "8.4.29",
@@ -3870,6 +3871,11 @@
         "loose-envify": "^1.0.0"
       }
     },
+    "node_modules/is-any-array": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-any-array/-/is-any-array-2.0.1.tgz",
+      "integrity": "sha512-UtilS7hLRu++wb/WBAw9bNuP1Eg04Ivn1vERJck8zJthEvXCBEBpGR/33u/xLKWEQf95803oalHrVDptcAvFdQ=="
+    },
     "node_modules/is-array-buffer": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
@@ -4461,6 +4467,78 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/ml-array-max": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/ml-array-max/-/ml-array-max-1.2.4.tgz",
+      "integrity": "sha512-BlEeg80jI0tW6WaPyGxf5Sa4sqvcyY6lbSn5Vcv44lp1I2GR6AWojfUvLnGTNsIXrZ8uqWmo8VcG1WpkI2ONMQ==",
+      "dependencies": {
+        "is-any-array": "^2.0.0"
+      }
+    },
+    "node_modules/ml-array-min": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/ml-array-min/-/ml-array-min-1.2.3.tgz",
+      "integrity": "sha512-VcZ5f3VZ1iihtrGvgfh/q0XlMobG6GQ8FsNyQXD3T+IlstDv85g8kfV0xUG1QPRO/t21aukaJowDzMTc7j5V6Q==",
+      "dependencies": {
+        "is-any-array": "^2.0.0"
+      }
+    },
+    "node_modules/ml-array-rescale": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/ml-array-rescale/-/ml-array-rescale-1.3.7.tgz",
+      "integrity": "sha512-48NGChTouvEo9KBctDfHC3udWnQKNKEWN0ziELvY3KG25GR5cA8K8wNVzracsqSW1QEkAXjTNx+ycgAv06/1mQ==",
+      "dependencies": {
+        "is-any-array": "^2.0.0",
+        "ml-array-max": "^1.2.4",
+        "ml-array-min": "^1.2.3"
+      }
+    },
+    "node_modules/ml-distance-euclidean": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ml-distance-euclidean/-/ml-distance-euclidean-2.0.0.tgz",
+      "integrity": "sha512-yC9/2o8QF0A3m/0IXqCTXCzz2pNEzvmcE/9HFKOZGnTjatvBbsn4lWYJkxENkA4Ug2fnYl7PXQxnPi21sgMy/Q=="
+    },
+    "node_modules/ml-kmeans": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ml-kmeans/-/ml-kmeans-6.0.0.tgz",
+      "integrity": "sha512-aziEZqeHxczaDvo1qkfCrC7XNVAPevs6PigAzy7dp9TzeQI7oGan6NfCgADwL/FAlA/wWi+1DkV8da6pXfuuPg==",
+      "dependencies": {
+        "ml-distance-euclidean": "^2.0.0",
+        "ml-matrix": "^6.9.0",
+        "ml-nearest-vector": "^2.0.1",
+        "ml-random": "^0.5.0"
+      }
+    },
+    "node_modules/ml-matrix": {
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/ml-matrix/-/ml-matrix-6.11.0.tgz",
+      "integrity": "sha512-7jr9NmFRkaUxbKslfRu3aZOjJd2LkSitCGv+QH9PF0eJoEG7jIpjXra1Vw8/kgao8+kHCSsJONG6vfWmXQ+/Eg==",
+      "dependencies": {
+        "is-any-array": "^2.0.1",
+        "ml-array-rescale": "^1.3.7"
+      }
+    },
+    "node_modules/ml-nearest-vector": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ml-nearest-vector/-/ml-nearest-vector-2.0.1.tgz",
+      "integrity": "sha512-gMPwNm3eed59ewJYiCK/+wElWBfNoD6JizH965ePiQgCo0pvQL63w4YdZhLs5eUV0iWcq6brVMUBL6iMySHnqg==",
+      "dependencies": {
+        "ml-distance-euclidean": "^2.0.0"
+      }
+    },
+    "node_modules/ml-random": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/ml-random/-/ml-random-0.5.0.tgz",
+      "integrity": "sha512-zLJBmNb34LOz+vN6BD8l3aYm/VWYWbmAunrLMPs4dHf4gTl8BWlhil72j56HubPg86zrXioIs4qoHq7Topy6tw==",
+      "dependencies": {
+        "ml-xsadd": "^2.0.0"
+      }
+    },
+    "node_modules/ml-xsadd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ml-xsadd/-/ml-xsadd-2.0.0.tgz",
+      "integrity": "sha512-VoAYUqmPRmzKbbqRejjqceGFp3VF81Qe8XXFGU0UXLxB7Mf4GGvyGq5Qn3k4AiQgDEV6WzobqlPOd+j0+m6IrA=="
     },
     "node_modules/ms": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "external-state": "^0.1.22",
     "geist": "^1.0.0",
     "lucide-react": "^0.307.0",
+    "ml-kmeans": "^6.0.0",
     "next": "latest",
     "open-color": "^1.9.1",
     "postcss": "8.4.29",

--- a/store/googleMapStore.ts
+++ b/store/googleMapStore.ts
@@ -1,6 +1,10 @@
 'use client';
 
-import { INITIAL_ZOOM_LEVEL } from 'constant/location';
+import {
+  INITIAL_ZOOM_LEVEL,
+  MAX_ZOOM_LEVEL,
+  MIN_ZOOM_LEVEL,
+} from 'constant/location';
 import { store } from 'external-state';
 import { isBrowser } from 'utils/isBrowser';
 
@@ -31,6 +35,17 @@ export const getGoogleMapStore = (() => {
         zoom: INITIAL_ZOOM_LEVEL,
         disableDefaultUI: true,
         mapId: process.env.NEXT_PUBLIC_MAPS_ID,
+        minZoom: MIN_ZOOM_LEVEL,
+        maxZoom: MAX_ZOOM_LEVEL,
+        gestureHandling: 'greedy',
+        restriction: {
+          latLngBounds: {
+            north: 39,
+            south: 32,
+            east: 132,
+            west: 124,
+          },
+        },
       });
     }
 


### PR DESCRIPTION
## :: 최근 작업 주제

- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표

- Chore: remove unnecessary element
- Feat: 구글 지도 줌 레벨 최소/최대 지정
- Chore: Traffic Hub 컴포넌트 분리
- Feat: 줌 레벨이 13보다 작을 경우(축소했을 떄), 마커를 렌더링하지 않도록 변경
- Feat: 줌 레벨에 따라 마커, 클러스터 데이터 패칭 분기 처리
- Feat: 클러스터 스타일, 애니메이션 추가
- Feat: 클러스터 타입 추가
- Feat: 유저의 뷰포트 기준, 클러스터 개수 10개 → 20개로 변경

<br/>

## :: 구현 사항 설명

- Feat: 구글 지도 줌 레벨 최소/최대 지정
  - 구글지도 기준은 우리나라만이 아닌 전 세계를 기준으로 함. 그래서 축소했을 때 우리나라 뷰포트를 벗어나 다른 나라의 지도가 보이는 경우가 있음.
  - 현재 교통량 데이터는 우리나라를 기준으로 하기에 restriction을 걸어줌

<br/>

- Feat: 줌 레벨이 13보다 작을 경우(축소했을 떄), 마커를 렌더링하지 않도록 변경
- Feat: 줌 레벨에 따라 마커, 클러스터 데이터 패칭 분기 처리
  - 줌 레벨이 13보다 작을 경우엔 **클러스터링을 렌더링**
  - 줌 레벨이 13보다 클 경우엔 **마커를 렌더링**

<br/>

- Feat: 클러스터 스타일, 애니메이션 추가
  - 마커와 클러스터링 모두 애니메이션 적용

<br/>

- Feat: 클러스터 타입 추가
- Feat: 유저의 뷰포트 기준, 클러스터 개수 10개 → 20개로 변경

<br/>

## :: 기타 질문 및 특이 사항

클러스터링 군집화 알고리즘은 k-means 알고리즘 라이브러리를 사용했음

- 몇 개로 묶어줄 것인지 정하는 k 값은 20개로 지정
- 임의의 k값을 20개로 지정했는데, 일반적으로 변동성이 가장 적은 K 값을 지정해줘야함
  - 여기서 변동성이란 건, 동일한 군집 내에 있는 데이터 끼리는 거리가 가깝게, 군집 간의 거리는 멀수록 좋음

[kmeans](https://github.com/mljs/kmeans)
