### PR TITLE
[Feat] isFetcing true 일 시, Loading 아이콘 적용

### DIFF
--- a/components/common/loading-component.tsx
+++ b/components/common/loading-component.tsx
@@ -1,0 +1,17 @@
+import { LoadingSpinner } from 'components/common/loading-spinner';
+
+interface LoadingIndicatorProps {
+  isFetching: boolean;
+}
+
+export const LoadingIndicator: React.FC<LoadingIndicatorProps> = ({
+  isFetching,
+}) => {
+  if (!isFetching) return null;
+
+  return (
+    <div className="centered-container">
+      <LoadingSpinner />
+    </div>
+  );
+};

--- a/components/map/marker-container.tsx
+++ b/components/map/marker-container.tsx
@@ -1,16 +1,11 @@
 import { type TrafficHub } from 'app/page';
 import { ClusterMapMarker } from 'components/map/cluster';
 import { TrafficMapMarker } from 'components/map/marker';
-import { useExternalValue } from 'external-state';
 import { useTrafficGetQuery } from 'hooks/useTrafficGetQuery';
-import { debounce } from 'lodash';
-import { useEffect, useState } from 'react';
-import { getGoogleMapStore } from 'store/googleMapStore';
-
-import { LoadingSpinner } from '../common/loading-spinner';
 
 type MarkerContainerProps = {
   selectedCategory: Set<string>;
+  currentZoomLevel: number;
 };
 
 export type Cluster = {
@@ -22,44 +17,12 @@ export type Cluster = {
 
 export const MarkerContainer: React.FC<MarkerContainerProps> = ({
   selectedCategory,
+  currentZoomLevel,
 }) => {
-  const mapStore = getGoogleMapStore?.();
-  if (!mapStore) return;
-  const googleMaps = useExternalValue(mapStore);
-  const [currentZoomLevel, setCurrentZoomLevel] = useState(
-    googleMaps?.getZoom(),
-  );
-
-  useEffect(() => {
-    if (!googleMaps) return;
-
-    const debouncedSetZoomLevel = debounce(() => {
-      setCurrentZoomLevel(googleMaps.getZoom());
-    }, 200);
-
-    const listener = googleMaps.addListener(
-      'zoom_changed',
-      debouncedSetZoomLevel,
-    );
-
-    return () => {
-      google.maps.event.removeListener(listener);
-      debouncedSetZoomLevel.cancel();
-    };
-  }, [googleMaps]);
-
-  const { data: traffic, isLoading } = useTrafficGetQuery({
+  const { data: traffic } = useTrafficGetQuery({
     categoryFilter: selectedCategory,
     currentZoomLevel,
   });
-
-  if (isLoading) {
-    return (
-      <div className="centered-container">
-        <LoadingSpinner />
-      </div>
-    );
-  }
 
   if (currentZoomLevel && currentZoomLevel <= 13) {
     return traffic?.map((cluster: Cluster) => (

--- a/components/map/traffic-hub.tsx
+++ b/components/map/traffic-hub.tsx
@@ -1,10 +1,20 @@
+import { LoadingIndicator } from 'components/common/loading-component';
 import { LegendCheckboxManager } from 'components/legend/checkbox-manager';
 import { MarkerContainer } from 'components/map/marker-container';
 import { useCategoryFilter } from 'hooks/useCategoryFilter';
+import { useGoogleMapsZoom } from 'hooks/useGoogleMapsZoom';
+import { useTrafficGetQuery } from 'hooks/useTrafficGetQuery';
 import { GoogleMap } from 'lib/google-map';
+
+import { INITIAL_ZOOM_LEVEL } from '@/constant/location';
 
 export const TrafficHubMap = () => {
   const { handleCategoryChange, selectedCategory } = useCategoryFilter();
+  const currentZoomLevel = useGoogleMapsZoom();
+  const { isFetching } = useTrafficGetQuery({
+    categoryFilter: selectedCategory,
+    currentZoomLevel: currentZoomLevel,
+  });
 
   return (
     <LegendCheckboxManager
@@ -12,7 +22,11 @@ export const TrafficHubMap = () => {
       handleCategoryChange={handleCategoryChange}
     >
       <GoogleMap />
-      <MarkerContainer selectedCategory={selectedCategory} />
+      <MarkerContainer
+        selectedCategory={selectedCategory}
+        currentZoomLevel={currentZoomLevel ?? INITIAL_ZOOM_LEVEL}
+      />
+      <LoadingIndicator isFetching={isFetching} />
     </LegendCheckboxManager>
   );
 };

--- a/hooks/useGoogleMapsZoom.ts
+++ b/hooks/useGoogleMapsZoom.ts
@@ -1,0 +1,36 @@
+import { useExternalValue } from 'external-state';
+import debounce from 'lodash/debounce';
+import { useEffect, useState } from 'react';
+import { getGoogleMapStore } from 'store/googleMapStore';
+
+import { INITIAL_ZOOM_LEVEL } from '@/constant/location';
+
+export const useGoogleMapsZoom = () => {
+  const mapStore = getGoogleMapStore?.();
+  if (!mapStore) return;
+  const googleMaps = useExternalValue(mapStore);
+
+  const [currentZoomLevel, setCurrentZoomLevel] = useState<number>(
+    googleMaps.getZoom() ?? INITIAL_ZOOM_LEVEL,
+  );
+
+  useEffect(() => {
+    if (!googleMaps) return;
+
+    const debouncedSetZoomLevel = debounce(() => {
+      setCurrentZoomLevel(googleMaps.getZoom() ?? INITIAL_ZOOM_LEVEL);
+    }, 200);
+
+    const listener = googleMaps.addListener(
+      'zoom_changed',
+      debouncedSetZoomLevel,
+    );
+
+    return () => {
+      google.maps.event.removeListener(listener);
+      debouncedSetZoomLevel.cancel();
+    };
+  }, [googleMaps]);
+
+  return currentZoomLevel;
+};


### PR DESCRIPTION
## :: 최근 작업 주제

- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표

- Feat: isFetcing true 일 시, Loading 아이콘 적용 #8

<br/>

## :: 구현 사항 설명

- Feat: isFetcing true 일 시, Loading 아이콘 적용 #8
  - 기존 `MarkerContainer`내부에 존재하던 google maps zoom level 변경하는 로직을 useGoogleMapsZoom hooks으로 만듦
  - 그리고 `MarkerContainer` 상위 부모 컴포넌트에서 동일하게 useGoogleMapsZoom hooks을 사용하도록 변경

<br/>

## :: 기타 질문 및 특이 사항

초반엔 관심사를 분리하지 못해서,

```TSX
if (currentZoomLevel && currentZoomLevel <= 13) {
    return traffic?.map((cluster: Cluster) => (
      <ClusterMapMarker key={cluster.id} cluster={cluster} />
    ));
  }

return traffic?.map((traffic: TrafficHub) => (
  <TrafficMapMarker key={traffic.id} traffic={traffic} />
));
```

위 부분에 isFetching을 추가하여 처리하려고 했다.
이렇게 했을 때 문제점은 계속 DOM에 data fetching으로 인해 마커가 다시 렌더링 된다는 점이다.

<br/>

```TSX
export const TrafficHubMap = () => {
  const { handleCategoryChange, selectedCategory } = useCategoryFilter();
  const currentZoomLevel = useGoogleMapsZoom();
  const { isFetching } = useTrafficGetQuery({
    categoryFilter: selectedCategory,
    currentZoomLevel: currentZoomLevel,
  });

  return (
    <LegendCheckboxManager
      selectedCategory={selectedCategory}
      handleCategoryChange={handleCategoryChange}
    >
      <GoogleMap />
      <MarkerContainer
        selectedCategory={selectedCategory}
        currentZoomLevel={currentZoomLevel ?? INITIAL_ZOOM_LEVEL}
      />
      <LoadingIndicator isFetching={isFetching} />
    </LegendCheckboxManager>
  );
};
```

하지만 컴포넌트를 아예 분리하고, useQuery hooks을 다시 불러와서(=useTrafficGetQuery) 인자값을 동일하게 넣어주면 해당 하는 모든 곳에서 trigger 되기에 같은 데이터 불러와서 다시 그리는 동안 일관되게 Loading 인디케이터를 띄울 수 있었다.

1. TrafficHubMap컴포넌트는 서버컴포넌트로 유지하고 싶었고,
2. 데이터렌더링이 사용자의 viewport가 변경됐을 때, 변경된 부분만 렌더링하고 싶었고,
3. 변경된 부분만 다시 불러와서 DOM에 그리는 동안 Loading Indicator를 띄워주고 싶었는데,

모두 완료할 수 있었다. 🙏
