### PR TITLE
[Feat] Teleport 버튼 추가

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -89,7 +89,7 @@
   padding: 1rem;
   background-color: hsl(var(--card));
   border-radius: calc(var(--radius) - 2px);
-  margin: 0.5rem;
+  margin: 0.5rem 6rem;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   gap: 0.5rem;
 }
@@ -117,17 +117,6 @@
   left: 50%;
   transform: translateX(-50%);
   z-index: 1;
-}
-
-/* Legend */
-.legend-container {
-  position: fixed;
-  margin: 1.5rem 0.5rem;
-  width: 16rem;
-  height: auto;
-  z-index: 20;
-  left: 0;
-  top: 4rem;
 }
 
 /* Marker Container */

--- a/components/legend/expandable-toggle-bar.tsx
+++ b/components/legend/expandable-toggle-bar.tsx
@@ -1,0 +1,91 @@
+import { REGION_COORDINATES } from 'constant/location';
+import { AnimatePresence, motion } from 'framer-motion';
+import Image from 'next/image';
+import { useEffect, useState } from 'react';
+import { getGoogleMapStore } from 'store/googleMapStore';
+
+type ExpandableToggleBarProps = {
+  children: React.ReactNode;
+};
+
+export const ExpandableToggleBar: React.FC<ExpandableToggleBarProps> = ({
+  children,
+}) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [selectedRegionValue, setSelectedRegionValue] = useState<string | null>(
+    null,
+  );
+  const mapStore = getGoogleMapStore?.();
+  const googleMap = mapStore?.getState();
+
+  useEffect(() => {
+    if (selectedRegionValue && googleMap) {
+      const selectedRegion = REGION_COORDINATES.find(
+        (region) => region.value === selectedRegionValue,
+      );
+
+      if (selectedRegion) {
+        const { latitude, longitude } = selectedRegion;
+
+        googleMap.moveCamera({
+          center: { lat: latitude, lng: longitude },
+          zoom: 10,
+        });
+      }
+    }
+  }, [googleMap, selectedRegionValue]);
+
+  const toggleBar = () => {
+    setIsExpanded(!isExpanded);
+  };
+
+  return (
+    <>
+      <div className="fixed bottom-0 right-0 z-20 m-5">
+        <div
+          className="cursor-pointer rounded-full bg-white"
+          onClick={toggleBar}
+        >
+          <Image
+            src="/favicon.png"
+            alt="expandable-toggle-bar"
+            width={50}
+            height={50}
+          />
+        </div>
+
+        <AnimatePresence>
+          {isExpanded && (
+            <motion.div
+              initial={{ height: 0 }}
+              animate={{ height: 'auto' }}
+              exit={{ height: 0 }}
+              transition={{ duration: 0.5, ease: 'easeInOut' }}
+              className="mt-2 overflow-hidden rounded-lg bg-white shadow-custom"
+            >
+              {REGION_COORDINATES.map((region) => {
+                return (
+                  <motion.div
+                    key={region.value}
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    exit={{ opacity: 0 }}
+                    transition={{ duration: 0.3 }}
+                    className="flex cursor-pointer items-center justify-center border-b border-gray-300 py-2"
+                    onClick={() => {
+                      setSelectedRegionValue(region.value);
+                    }}
+                  >
+                    {region.label}
+                  </motion.div>
+                );
+              })}
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </div>
+
+      {children}
+    </>
+  );
+};

--- a/components/legend/side-menu-bar.tsx
+++ b/components/legend/side-menu-bar.tsx
@@ -1,5 +1,3 @@
-import { useState } from 'react';
-
 type SideMenuBarProps = {
   children: React.ReactNode;
 };
@@ -7,9 +5,11 @@ type SideMenuBarProps = {
 export const SideMenuBar: React.FC<SideMenuBarProps> = ({ children }) => {
   return (
     <>
+      {/* 
+      FIXME: 기능개발할 것
       <div className="fixed left-0 top-0 z-10 h-full w-20 bg-white">
         여기는 Menu Tab
-      </div>
+      </div> */}
       {children}
     </>
   );

--- a/components/legend/side-menu-bar.tsx
+++ b/components/legend/side-menu-bar.tsx
@@ -1,0 +1,16 @@
+import { useState } from 'react';
+
+type SideMenuBarProps = {
+  children: React.ReactNode;
+};
+
+export const SideMenuBar: React.FC<SideMenuBarProps> = ({ children }) => {
+  return (
+    <>
+      <div className="fixed left-0 top-0 z-10 h-full w-20 bg-white">
+        여기는 Menu Tab
+      </div>
+      {children}
+    </>
+  );
+};

--- a/components/map/traffic-hub.tsx
+++ b/components/map/traffic-hub.tsx
@@ -1,12 +1,13 @@
 import { LoadingIndicator } from 'components/common/loading-component';
+import { ExpandableToggleBar } from 'components/legend/expandable-toggle-bar';
+import { SideMenuBar } from 'components/legend/side-menu-bar';
 import { LegendToggleButtonManager } from 'components/legend/toggle-button-manager';
 import { MarkerContainer } from 'components/map/marker-container';
+import { INITIAL_ZOOM_LEVEL } from 'constant/location';
 import { useCategoryFilter } from 'hooks/useCategoryFilter';
 import { useGoogleMapsZoom } from 'hooks/useGoogleMapsZoom';
 import { useTrafficGetQuery } from 'hooks/useTrafficGetQuery';
 import { GoogleMap } from 'lib/google-map';
-
-import { INITIAL_ZOOM_LEVEL } from '@/constant/location';
 
 export const TrafficHubMap = () => {
   const { handleCategoryChange, selectedCategory } = useCategoryFilter();
@@ -17,16 +18,20 @@ export const TrafficHubMap = () => {
   });
 
   return (
-    <LegendToggleButtonManager
-      selectedCategory={selectedCategory}
-      handleCategoryChange={handleCategoryChange}
-    >
-      <GoogleMap />
-      <MarkerContainer
+    <SideMenuBar>
+      <LegendToggleButtonManager
         selectedCategory={selectedCategory}
-        currentZoomLevel={currentZoomLevel ?? INITIAL_ZOOM_LEVEL}
-      />
-      <LoadingIndicator isFetching={isFetching} />
-    </LegendToggleButtonManager>
+        handleCategoryChange={handleCategoryChange}
+      >
+        <ExpandableToggleBar>
+          <GoogleMap />
+          <MarkerContainer
+            selectedCategory={selectedCategory}
+            currentZoomLevel={currentZoomLevel ?? INITIAL_ZOOM_LEVEL}
+          />
+          <LoadingIndicator isFetching={isFetching} />
+        </ExpandableToggleBar>
+      </LegendToggleButtonManager>
+    </SideMenuBar>
   );
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "dependencies": {
         "@googlemaps/react-wrapper": "^1.1.35",
+        "@lukemorales/query-key-factory": "^1.3.3",
         "@radix-ui/react-checkbox": "^1.0.4",
         "@radix-ui/react-icons": "^1.3.0",
         "@radix-ui/react-label": "^2.0.2",
@@ -22,6 +23,7 @@
         "clsx": "^2.1.0",
         "density-clustering": "^1.3.0",
         "external-state": "^0.1.22",
+        "framer-motion": "^11.0.8",
         "geist": "^1.0.0",
         "lodash": "^4.17.21",
         "lucide-react": "^0.307.0",
@@ -92,6 +94,21 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
+      "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
+      "optional": true,
+      "dependencies": {
+        "@emotion/memoize": "0.7.4"
+      }
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
+      "optional": true
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
@@ -361,6 +378,18 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@lukemorales/query-key-factory": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@lukemorales/query-key-factory/-/query-key-factory-1.3.3.tgz",
+      "integrity": "sha512-oB4q2lupWLqDN0eLCsKMdXMbB3dwAGuSQBA2U6StxwDmbmt6yw/x5yqNb28bUWzR1tlZR5PgFDRw7g0ee9qpmg==",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@tanstack/query-core": ">= 4.0.0",
+        "@tanstack/react-query": ">= 4.0.0"
       }
     },
     "node_modules/@next/env": {
@@ -3508,6 +3537,29 @@
       "funding": {
         "type": "patreon",
         "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/framer-motion": {
+      "version": "11.0.8",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.0.8.tgz",
+      "integrity": "sha512-1KSGNuqe1qZkS/SWQlDnqK2VCVzRVEoval379j0FiUBJAZoqgwyvqFkfvJbgW2IPFo4wX16K+M0k5jO23lCIjA==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "optionalDependencies": {
+        "@emotion/is-prop-valid": "^0.8.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/fs.realpath": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@googlemaps/react-wrapper": "^1.1.35",
+    "@lukemorales/query-key-factory": "^1.3.3",
     "@radix-ui/react-checkbox": "^1.0.4",
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-label": "^2.0.2",
@@ -26,6 +27,7 @@
     "clsx": "^2.1.0",
     "density-clustering": "^1.3.0",
     "external-state": "^0.1.22",
+    "framer-motion": "^11.0.8",
     "geist": "^1.0.0",
     "lodash": "^4.17.21",
     "lucide-react": "^0.307.0",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -71,6 +71,9 @@ module.exports = {
         'accordion-down': 'accordion-down 0.2s ease-out',
         'accordion-up': 'accordion-up 0.2s ease-out',
       },
+      boxShadow: {
+        custom: '0 2px 4px rgba(0, 0, 0, 0.1)',
+      },
     },
   },
   plugins: [require('tailwindcss-animate')],


### PR DESCRIPTION
<img width="830" alt="스크린샷 2024-03-10 오전 12 03 33" src="https://github.com/Geuni620/Traffic-Hub/assets/56650238/d9b682b9-9549-47b6-abcf-76295aab44c1">



## :: 최근 작업 주제

- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표

- feat: add teleport button

<br/>

## :: 구현 사항 설명

- feat: add teleport button
  - 클릭을 할 때마다, 해당 지역으로 카메라를 이동시켜주는 버튼을 만들었음
  - 처음엔, panTo와 setZoom으로 구현했었는데, 다음과 같은 이슈 발생
    - 아이콘을 클릭하고, 나타난 지역리스트 중 최초 클릭 시, 특정 위치로만 이동해버림
    - 원인분석 결과, useEffect내에서, googleMap의 setZoom과 panTo가 순차적으로 실행되지 못했음
    - 즉, panTo 도중 setZoom 되어버려서 panTo가 멈춰버림
  - 해결방안으로, googleMap에서 제공하는 **moveCamera** 메서드를 통해 이동을 구현할 수 있었음

<br/>

- style은 framer-motion을 사용하였음
  - AnimatePresence는 자식 컴포넌트가 마운트되거나 언마운트될 때 애니메이션을 적용할 수 있게 해줌

<br/>

## :: 기타 질문 및 특이 사항

-
